### PR TITLE
Use secure tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ $ open docs/build/html/index.html
 ## TODO
 
 * Better persistence of the database with Docker volumes (maybe a different service or container for persistence).
-* Better auth tokens, see https://flask-login.readthedocs.org/en/latest/#remember-me.
 * Perhaps login should happen after signup, this should be factored out.
 * API responses should have good messages, data, not just status codes
 * Automated, good API docs (instead of this terrible README solution) probably sphinxcontrib.autohttp.flask

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To build the documentation locally, install the development requirements and the
 (my_virtualenv)$ make -C docs/ html
 ```
 
-To view this build documentation, run:
+To view this built documentation, run:
 
 ```
 $ open docs/build/html/index.html

--- a/authentication/authentication.py
+++ b/authentication/authentication.py
@@ -26,14 +26,21 @@ class User(db.Model, UserMixin):
 
     def get_auth_token(self):
         """
-        TODO
+        See https://flask-login.readthedocs.org/en/latest/#alternative-tokens
+
+        :return: A secure token unique to this ``User`` with the current
+            ``password_hash``.
+        :rtype: string
         """
         return make_secure_token(self.email, self.password_hash)
 
     def get_id(self):
         """
-        Return the email address to satify Flask-Login's requirements. This is
-        used in conjunction with ``load_user`` for session management
+        See https://flask-login.readthedocs.org/en/latest/#your-user-class
+
+        :return: the email address to satify Flask-Login's requirements. This
+            is used in conjunction with ``load_user`` for session management.
+        :rtype: string
         """
         return self.email
 

--- a/authentication/authentication.py
+++ b/authentication/authentication.py
@@ -25,7 +25,11 @@ class User(db.Model, UserMixin):
     password_hash = db.Column(db.String)
 
     def get_auth_token(self):
-        return make_secure_token(email=self.email, password_hash=self.password_hash)
+        """
+        TODO
+        """
+        return make_secure_token(email=self.email,
+                                 password_hash=self.password_hash)
 
     def get_id(self):
         """

--- a/authentication/authentication.py
+++ b/authentication/authentication.py
@@ -56,7 +56,7 @@ def create_app(database_uri):
     """
     app = Flask(__name__)
     app.config['SQLALCHEMY_DATABASE_URI'] = database_uri
-    app.config['SECRET_KEY'] = 'secret'
+    app.config['SECRET_KEY'] = os.environ.get('SECRET', 'secret')
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = True
     db.init_app(app)
 

--- a/authentication/authentication.py
+++ b/authentication/authentication.py
@@ -28,8 +28,7 @@ class User(db.Model, UserMixin):
         """
         TODO
         """
-        return make_secure_token(email=self.email,
-                                 password_hash=self.password_hash)
+        return make_secure_token(self.email, self.password_hash)
 
     def get_id(self):
         """

--- a/authentication/authentication.py
+++ b/authentication/authentication.py
@@ -76,17 +76,19 @@ login_manager.init_app(app)
 @login_manager.user_loader
 def load_user_from_id(user_id):
     """
-    Flask-Login user_loader callback.
+    Flask-Login ``user_loader`` callback.
 
-    The user_loader function asks this function to get a User object based on
-    the user_id. If there is no user with the current userid (where user_id is
-    the result of ``User.get_id``), return None.
-
-    The user_id was stored in the session environment by Flask-Login.
-    user_loader stores the returned User object in current_user during every
-    flask request.
+    The ``user_id`` was stored in the session environment by Flask-Login.
+    user_loader stores the returned ``User`` object in ``current_user`` during
+    every flask request.
 
     See https://flask-login.readthedocs.org/en/latest/#flask.ext.login.LoginManager.user_loader.  # noqa
+
+    :param user_id: The ID of the user Flask is trying to load.
+    :type user_id: string
+    :return: The user which has the email address ``user_id`` or ``None`` if
+        there is no such user.
+    :rtype: ``User`` or ``None``.
     """
     return User.query.filter_by(email=user_id).first()
 
@@ -94,7 +96,16 @@ def load_user_from_id(user_id):
 @login_manager.token_loader
 def load_user_from_token(auth_token):
     """
-    TODO
+    Flask-Login token-loader callback.
+
+    See https://flask-login.readthedocs.org/en/latest/#flask.ext.login.LoginManager.token_loader  # noqa
+
+    :param auth_token: The authentication token of the user Flask is trying to
+        load.
+    :type user_id: string
+    :return: The user which has the given authentication token or ``None`` if
+        there is no such user.
+    :rtype: ``User`` or ``None``.
     """
     for user in User.query.all():
         if user.get_auth_token() == auth_token:

--- a/authentication/authentication.py
+++ b/authentication/authentication.py
@@ -86,7 +86,9 @@ def load_user_from_token(auth_token):
     """
     TODO
     """
-    return User.query.filter_by(email='email').first()
+    for user in User.query.all():
+        if user.get_auth_token() == auth_token:
+            return user
 
 
 @app.route('/login', methods=['POST'])

--- a/authentication/tests/test_authentication.py
+++ b/authentication/tests/test_authentication.py
@@ -191,9 +191,17 @@ class LoadUserTests(DatabaseTestCase):
             self.assertIsNone(load_user_from_id(user_id='email'))
 
 
-class LoadFromTokenTests(DatabaseTestCase):
+class LoadUserFromTokenTests(DatabaseTestCase):
+    """
+    Tests for ``load_user_from_token``, which is a function required by
+    Flask-Login when using secure "Alternative Tokens".
+    """
 
-    def test_load(self):
+    def test_load_user_from_token(self):
+        """
+        A user is loaded if their token is provided to
+        ``load_user_from_token``.
+        """
         self.app.post('/signup', data=USER_DATA)
         response = self.app.post('/login', data=USER_DATA)
         cookies = response.headers.getlist('Set-Cookie')
@@ -203,7 +211,6 @@ class LoadFromTokenTests(DatabaseTestCase):
         token = headers_dict['remember_token']
         with app.app_context():
             user = load_user_from_id(user_id=USER_DATA['email'])
-            self.assertEqual(token, user.get_auth_token())
             self.assertEqual(load_user_from_token(auth_token=token), user)
 
 

--- a/authentication/tests/test_authentication.py
+++ b/authentication/tests/test_authentication.py
@@ -168,13 +168,14 @@ class LogoutTests(DatabaseTestCase):
 
 class LoadUserTests(DatabaseTestCase):
     """
-    Tests for ``load_user_from_id``, which is a function required by Flask-Login.
+    Tests for ``load_user_from_id``, which is a function required by
+    Flask-Login.
     """
 
     def test_user_exists(self):
         """
-        If a user exists with the email given as the user ID to ``load_user_from_id``,
-        that user is returned.
+        If a user exists with the email given as the user ID to
+        ``load_user_from_id``, that user is returned.
         """
         self.app.post('/signup', data=USER_DATA)
         with app.app_context():
@@ -183,8 +184,8 @@ class LoadUserTests(DatabaseTestCase):
 
     def test_user_does_not_exist(self):
         """
-        If no user exists with the email given as the user ID to ``load_user_from_id``,
-        ``None`` is returned.
+        If no user exists with the email given as the user ID to
+        ``load_user_from_id``, ``None`` is returned.
         """
         with app.app_context():
             self.assertIsNone(load_user_from_id(user_id='email'))
@@ -204,6 +205,7 @@ class LoadFromTokenTests(DatabaseTestCase):
             user = load_user_from_id(user_id=USER_DATA['email'])
             self.assertEqual(token, user.get_auth_token())
             self.assertEqual(load_user_from_token(auth_token=token), user)
+
 
 class UserTests(DatabaseTestCase):
     """

--- a/authentication/tests/test_authentication.py
+++ b/authentication/tests/test_authentication.py
@@ -213,6 +213,13 @@ class LoadUserFromTokenTests(DatabaseTestCase):
             user = load_user_from_id(user_id=USER_DATA['email'])
             self.assertEqual(load_user_from_token(auth_token=token), user)
 
+    def test_fake_token(self):
+        pass
+
+    def test_modified_password(self):
+        pass
+
+# TODO direct token creation tests
 
 class UserTests(DatabaseTestCase):
     """

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,5 @@ web:
    - /tmp/authentication:/data
   environment:
    - SQLALCHEMY_DATABASE_URI=sqlite:////data/authentication.db
+   - SECRET
   command: python authentication/authentication.py


### PR DESCRIPTION
Use more secure tokens for token based login

**DO NOT MERGE**

I'd like `direct-flask-login-tests` to be merged first, but this can be reviewed whenever.
