### PR TITLE
Re-add coveralls requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   # on Python 3.
   - "if [[ $TRAVIS_PYTHON_VERSION < 3 ]]; then pip install linkchecker; fi"
   - "pip install -e .[dev]"
+  - "pip install coverage"
 before_script:
   # Run various code analysis tools, for linting and correctness:
   - "flake8 ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ install:
   # on Python 3.
   - "if [[ $TRAVIS_PYTHON_VERSION < 3 ]]; then pip install linkchecker; fi"
   - "pip install -e .[dev]"
-  - "pip install coverage"
 before_script:
   # Run various code analysis tools, for linting and correctness:
   - "flake8 ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
 after_success:
   # Sends the coverage report to coveralls.io which can report to Pull Requests
   # and track test coverage over time.
-  - "coveralls"
+  "coveralls"
 # Cache pip dependencies.
 # See http://docs.travis-ci.com/user/caching/#pip-cache.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
 after_success:
   # Sends the coverage report to coveralls.io which can report to Pull Requests
   # and track test coverage over time.
-  "coveralls"
+  - "coveralls"
 # Cache pip dependencies.
 # See http://docs.travis-ci.com/user/caching/#pip-cache.
 cache:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-coverage # Allows us to measure code coverage
 doc8 # Style check documentation
 flake8 # Code analysis tool with linting
 PyEnchant # Dictionary interaction for spellchecking

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+coverage # Allows us to measure code coverage
 doc8 # Style check documentation
 flake8 # Code analysis tool with linting
 PyEnchant # Dictionary interaction for spellchecking

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 coverage # Allows us to measure code coverage
+coveralls # Allows us to upload coverage data
 doc8 # Style check documentation
 flake8 # Code analysis tool with linting
 PyEnchant # Dictionary interaction for spellchecking


### PR DESCRIPTION
Somewhere in the mix, coveralls got lost as a requirement. Re-add it and make it necessary for PRs to have a coveralls report to be merged (so it won't go away again).
